### PR TITLE
Fix escape strategy for newer versions of metro

### DIFF
--- a/src/plugin/html.js
+++ b/src/plugin/html.js
@@ -1,9 +1,9 @@
 import { ROOT_ID } from "../common";
 
-const escape = (src) => src.replace(/`/g, "\\`");
-
-export const createContent = (js) =>
-  `export default String.raw\`${escape(wrapByHtml(js))}\`;`;
+export const createContent = (js) => { 
+  js = js.replace(/([`$])/g, '\\$1');
+  return "export default String.raw`\n"+wrapByHtml(js)+"\n`.replace(/\\\\([`$])/g, '\\$1')"; 
+}
 
 const wrapByHtml = (js) => `
 <!DOCTYPE html>


### PR DESCRIPTION
Newer versions of metro (expo 49) use js template strings which aren't escaped properly with the old strategy. 

I'm not an expert on how to escape these strings but this seems to work for me. 

https://github.com/inokawa/react-native-react-bridge/issues/126#issuecomment-1687511906