### PR TITLE
fix: escape ${ var }

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -40,8 +40,8 @@ export const transform = async (args: any /* TODO */) => {
       ...args,
       src:
         "export default String.raw`" +
-        escape(res) +
-        "`.replace(/\\\\([`$])/g, '\\$1')",
+        escape(res).replace(/\$\{(.*?)\}/g, '\\$\\{$1\\}') +
+        "`.replace(/\\\\([`${}])/g, '\\$1')",
     });
   }
 


### PR DESCRIPTION
escape ${var} which is causing error
`Property 'zh' doesn't exist`

should fix issues 
fix #183
fix #181 