### PR TITLE
Feat/better escape

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -44,7 +44,7 @@ export const createTransformer = (
         ...args,
         src:
           "export default String.raw`" +
-          escape(res).replace(/\$\{(.*?)\}/g, "\\$\\{$1\\}") +
+          escape(res).replace(/\$/g, '\\$') +
           "`.replace(/\\\\([`$])/g, '\\$1')",
       });
     }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -45,7 +45,7 @@ export const createTransformer = (
         src:
           "export default String.raw`" +
           escape(res).replace(/\$\{(.*?)\}/g, "\\$\\{$1\\}") +
-          "`.replace(/\\\\([`${}])/g, '\\$1')",
+          "`.replace(/\\\\([`$])/g, '\\$1')",
       });
     }
 


### PR DESCRIPTION
There might be nested or edge combination that failed previous escape 
`.replace(/\$\{(.*?)\}/g, '\\$\\{$1\\}')`
replacing with simpler strategy that prevents the compiled string from expecting a variable
`.replace(/\$/g, '\\$')`


This might fix the issue #182 