### PR TITLE
Fix backticks escaping

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -6,7 +6,7 @@
 
 import type { BuildOptions } from "esbuild";
 import { isEntryFile } from "./babel";
-import { RNRBConfig, bundle, escape } from "./bundler";
+import { RNRBConfig, bundle } from "./bundler";
 import { join } from "path";
 
 const metroTransformer = (() => {
@@ -42,10 +42,7 @@ export const createTransformer = (
       const res = await bundle(filename, metroOptions, esbuildOptions);
       return metroTransformer.transform({
         ...args,
-        src:
-          "export default String.raw`" +
-          escape(res).replace(/\$/g, '\\$') +
-          "`.replace(/\\\\([`$])/g, '\\$1')",
+        src: "export default " + JSON.stringify(res),
       });
     }
 


### PR DESCRIPTION
Manually escaping characters for `String.raw` is not a trivial task and can cause errors #144 #181 #182 #198 etc.
Also, the need for postprocessing during initialization with `replace` slows down loading of large bundles.

This PR uses the standard js function `JSON.stringify` to escape the final html file.

Additional question. The code also uses `` ` `` escaping in string and css files. Why was this done? It seems that this can only create problems (for example, if the string already contains an escaped `` \` ``).